### PR TITLE
Use dbt variables as an alternative way to get execution_date

### DIFF
--- a/macros/execution_date.sql
+++ b/macros/execution_date.sql
@@ -1,5 +1,5 @@
 {%- macro execution_date(timezone=none) -%}
-    {%- set execution_date_str = env_var('EXECUTION_DATE', "none") -%}
+    {%- set execution_date_str = env_var('EXECUTION_DATE', var('execution_date', "none")) -%}
     {%- set _execution_date = none -%}
 
     {%- if execution_date_str == "none" -%}


### PR DESCRIPTION
Hi,

I currently use `dbt-rpc` to control my dbt project over http-rpc, so passing an environment variable for each run is not possible.

I think this PR will benefit others who are using `dbt-rpc` also.

Thanks